### PR TITLE
Add logic to remove images using copy_sub.sh and update_sub.sh

### DIFF
--- a/copy_sub.sh
+++ b/copy_sub.sh
@@ -3,16 +3,23 @@
 # Source the variables in variables.sh
 . variables.sh
 
+
 SUBMARINER_REPOS=( $( ls . ) )
 for REPO in "${SUBMARINER_REPOS[@]}"
 do
   if [[ -d ${REPO} ]] ; then
+    DIFF_FILE_EXISTED=false
+
     echo "Evaluating \"${REPO}\":"
     pushd ${REPO} &>/dev/null
 
-    echo "Remove existing diff file:"
-    echo "  rm -f ${SUBMARINER_DIFF_FILENAME}"
-    rm -f "${SUBMARINER_DIFF_FILENAME}"
+    if [[ -f "$SUBMARINER_DIFF_FILENAME" ]]; then
+      echo "Remove existing diff file:"
+      echo "  rm -f ${SUBMARINER_DIFF_FILENAME}"
+      rm -f "${SUBMARINER_DIFF_FILENAME}"
+
+      DIFF_FILE_EXISTED=true
+    fi
 
     echo "Remove any exiting changes:"
     echo "  git checkout ."
@@ -41,7 +48,12 @@ do
       git apply ${SUBMARINER_DIFF_FILENAME}
       rm -f ${SUBMARINER_DIFF_FILENAME}
     else
-      echo "No diff file found."
+      if [[ "$DIFF_FILE_EXISTED" == "true" ]]; then
+        echo "Previously existing diff file found, but none now. Delete images ..."
+        remove_repo_images ${REPO}
+      else
+        echo "No diff file found."
+      fi
     fi
 
     popd &>/dev/null

--- a/docker_login.diff
+++ b/docker_login.diff
@@ -11,13 +11,53 @@ index d2e8c93..69d6980 100644
      DAPPER_SOURCE=/go/src/github.com/submariner-io/${PROJECT} DAPPER_DOCKER_SOCKET=true
  ENV DAPPER_OUTPUT=${DAPPER_SOURCE}/output
  
+diff --git a/scripts/shared/build_image.sh b/scripts/shared/build_image.sh
+index 4708b9b..94f6fa5 100755
+--- a/scripts/shared/build_image.sh
++++ b/scripts/shared/build_image.sh
+@@ -34,6 +34,15 @@ set -e
+ local_image=${repo}/${image}:${tag}
+ cache_image=${repo}/${image}:${CUTTING_EDGE}
+ 
++if [[ -n "${DOCKER_USER}" ]] ; then
++    DOCKER_PASSWD_FILE=".docker_file"
++    echo "${DOCKER_PASSWD}" > "${DOCKER_PASSWD_FILE}"
++    docker_login ${DOCKER_USER} ${DOCKER_PASSWD_FILE}
++    rm -f "${DOCKER_PASSWD_FILE}"
++    unset DOCKER_PASSWD
++    unset DOCKER_PASSWD_FILE
++fi
++
+ # When using cache pull latest image from the repo, so that it's layers may be reused.
+ cache_flag=''
+ if [[ "$cache" = true ]]; then
 diff --git a/scripts/shared/clusters.sh b/scripts/shared/clusters.sh
-index 28547e9..4995922 100755
+index 9add415..34cfd79 100755
 --- a/scripts/shared/clusters.sh
 +++ b/scripts/shared/clusters.sh
-@@ -44,6 +44,27 @@ set -em
+@@ -44,6 +44,15 @@ set -em
  source ${SCRIPTS_DIR}/lib/debug_functions
  source ${SCRIPTS_DIR}/lib/utils
+ 
++if [[ -n "${DOCKER_USER}" ]] ; then
++    DOCKER_PASSWD_FILE=".docker_file"
++    echo "${DOCKER_PASSWD}" > "${DOCKER_PASSWD_FILE}"
++    docker_login ${DOCKER_USER} ${DOCKER_PASSWD_FILE}
++    rm -f "${DOCKER_PASSWD_FILE}"
++    unset DOCKER_PASSWD
++    unset DOCKER_PASSWD_FILE
++fi
++
+ ### Functions ###
+ 
+ function generate_cluster_yaml() {
+diff --git a/scripts/shared/lib/debug_functions b/scripts/shared/lib/debug_functions
+index e591afc..530a177 100644
+--- a/scripts/shared/lib/debug_functions
++++ b/scripts/shared/lib/debug_functions
+@@ -7,6 +7,20 @@ NO_COLOR=$(echo -e '\e[0m')
+ 
+ ### Functions ###
  
 +function docker_login() {
 +    login="$1"
@@ -33,13 +73,6 @@ index 28547e9..4995922 100755
 +    fi
 +}
 +
-+DOCKER_PASSWD_FILE="${DAPPER_OUTPUT}/.docker_file"
-+echo "${DOCKER_PASSWD}" > "${DOCKER_PASSWD_FILE}"
-+docker_login ${DOCKER_USER} ${DOCKER_PASSWD_FILE}
-+rm -f "${DOCKER_PASSWD_FILE}"
-+unset DOCKER_PASSWD
-+unset DOCKER_PASSWD_FILE
-+
- ### Functions ###
- 
- function generate_cluster_yaml() {
+ function trap_commands() {
+     # Function to print each bash command before it is executed
+     trap 'cmd="$BASH_COMMAND" &&

--- a/gen_diff_sub.sh
+++ b/gen_diff_sub.sh
@@ -18,6 +18,9 @@ do
     if [ "$HEADHASH" != "$UPSTREAMHASH" ] ; then
         echo "Changes detect, regenerate diff file: ${SUBMARINER_DIFF_FILENAME}"
         git diff HEAD^ > "${SUBMARINER_DIFF_FILENAME}"
+    elif [[ `git status --porcelain` ]]; then
+        echo "Changes detect, regenerate diff file: ${SUBMARINER_DIFF_FILENAME}"
+        git diff > "${SUBMARINER_DIFF_FILENAME}"
     fi
 
     popd &>/dev/null

--- a/install_docker_login.sh
+++ b/install_docker_login.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Source the variables in variables.sh
+. variables.sh
+
+# Make sure Shipyard directory exists
+if [[ -d "${SUBMARINER_BASE_DIRECTORY}/shipyard/" ]] ; then
+  # Apply the patch
+  echo "Copying \"docker_login.diff\" to \"shipyard/\" and applying ..."
+  cp docker_login.diff "${SUBMARINER_BASE_DIRECTORY}/shipyard/."
+  pushd "${SUBMARINER_BASE_DIRECTORY}/shipyard/" &>/dev/null
+  git apply docker_login.diff
+  popd &>/dev/null
+
+  # Update Dockerfile.dapper in all the existing repos
+  pushd "${SUBMARINER_BASE_DIRECTORY}" &>/dev/null
+  SUBMARINER_REPOS=( $( ls . ) )
+  for REPO in "${SUBMARINER_REPOS[@]}"
+  do
+    if [[ -d ${REPO} ]] ; then
+      if [[ "${REPO}" != "shipyard" ]]; then
+        echo "Copying \"Dockerfile.dapper\" to \"${REPO}\""
+        pushd ${REPO} &>/dev/null
+        cp ../shipyard/Dockerfile.dapper . 
+        popd &>/dev/null
+      fi  
+    fi
+  done
+  popd &>/dev/null  
+else
+  echo "${SUBMARINER_BASE_DIRECTORY}/shipyard/ does not exist"
+fi
+

--- a/setup_sub.sh
+++ b/setup_sub.sh
@@ -30,6 +30,7 @@ fi
 mkdir -p ${SUBMARINER_BASE_DIRECTORY}
 
 echo "Deployment mode: $SUBMARINER_DEPLOY"
+echo "Copying scripts ..."
 if [[ "${SUBMARINER_DEPLOY}" == "local"  ]] ; then
   cp gen_diff_sub.sh ${SUBMARINER_BASE_DIRECTORY}/.
   cp update_sub.sh ${SUBMARINER_BASE_DIRECTORY}/.

--- a/update_sub.sh
+++ b/update_sub.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Source the variables in variables.sh
+. variables.sh
+
 SUBMARINER_REPOS=( $( ls . ) )
 
 for REPO in "${SUBMARINER_REPOS[@]}"
@@ -31,6 +34,12 @@ do
       if [ $? != 0 ]; then
         echo "  *** Failed for repo \"${REPO}\". ***"
       fi
+
+      # Since nothing has changed in this repo, delete images associated
+      # with repo in case there are local changes.
+      echo "Removing all images for \"${REPO}\" ..."
+      remove_repo_images "${REPO}"
+
     else
       echo "  *** Project \"${REPO}\" has local changes, manual updating required! ***"
     fi

--- a/variables.sh
+++ b/variables.sh
@@ -4,3 +4,79 @@ SUBMARINER_USER=${SUBMARINER_USER:-$USER}
 SUBMARINER_SERVER_IP=${SUBMARINER_SERVER_IP:-"10.8.125.32"}
 SUBMARINER_BASE_DIRECTORY=${SUBMARINER_BASE_DIRECTORY:-"/home/${SUBMARINER_USER}/src/submariner-io"}
 SUBMARINER_DIFF_FILENAME="submariner_patch.diff"
+
+
+# This is similar to `make prune-images` except that `make prune-images`
+# deletes EVERYTHING. This just deletes images associated with the given
+# input repo. Images "<none>" and "quay.io/submariner/shipyard-dapper-base"
+# are left behind because there is noway to determine if they are used by
+# another repo or not.
+function remove_repo_images() {
+  LCL_REPO="$1"
+
+  case $LCL_REPO in
+
+    admiral)
+      IMAGE_LIST="admiral"
+      ;;
+
+    coastguard)
+      IMAGE_LIST="coastguard"
+      ;;
+
+    lighthouse)
+      IMAGE_LIST="lighthouse-agent|lighthouse-coredns"
+      ;;
+
+    shipyard)
+      IMAGE_LIST="nettest|shipyard-dapper-base|shipyard-linting"
+      ;;
+
+    submariner)
+      IMAGE_LIST="submariner-gateway|submariner-globalnet|submariner-networkplugin-syncer|submariner-route-agent"
+      ;;
+
+    submariner-operator)
+      IMAGE_LIST="submariner-operator|submariner-operator-index"
+      ;;
+
+    submariner-website)
+      IMAGE_LIST=""
+      ;;
+
+    *)
+      IMAGE_LIST=""
+      ;;
+  esac
+
+  # This handles images like:
+  # $ docker images
+  # REPOSITORY                                     TAG     IMAGE ID       CREATED         SIZE
+  # localhost:5000/submariner-operator-index       local   e8cadf267d1f   44 hours ago    37MB
+  # quay.io/submariner/submariner-operator-index   dev     e8cadf267d1f   44 hours ago    37MB
+  # quay.io/submariner/submariner-operator-index   devel   e8cadf267d1f   44 hours ago    37MB
+  if [[ -n "${IMAGE_LIST}" ]]; then
+    docker images | grep -E "(${IMAGE_LIST})" | while read IMAGE_NAME TAG IMAGE_ID _; do
+      if [ "${TAG}" != "<none>" ]; then
+        echo "Running: docker rmi ${IMAGE_NAME}:${TAG}"
+        docker rmi "${IMAGE_NAME}":"${TAG}"
+      else
+        echo "Running: docker rmi ${IMAGE_ID}"
+        docker rmi "${IMAGE_ID}"
+      fi
+    done
+  fi
+
+  # This handles images like:
+  # $ docker images
+  # REPOSITORY                                     TAG     IMAGE ID       CREATED         SIZE
+  # :
+  # submariner                                     devel   4354944c763c   44 hours ago    953MB
+  #
+  # Because grepping for `submariner` would delete almost all images.
+  IMAGE_ID=$(docker images -q "${LCL_REPO}")
+  if [[ -n "${IMAGE_ID}" ]]; then
+      echo "Running: docker rmi ${IMAGE_ID}"
+      docker rmi "${IMAGE_ID}"
+  fi
+}


### PR DESCRIPTION
Local images can hang around even though a PR has merged and working branch
deleted.
* Updated copy_sub.sh on the remote side to remove repo image if it detects
  there are no more changes to the repo, but submariner_patch.diff still
  exists.
* Updated update_sub.sh on the local side to remove repo image if it detects
  there are no changes to the repo.

Updated the Docker Login patch to also login to Docker on builds. Hit rate
limit multiple times when trying to build to test this PR. Also added
install_docker_login.sh to apply the patch and copy Dockerfile.dapper to
all the repos.

Signed-off-by: Billy McFall <22157057+Billy99@users.noreply.github.com>